### PR TITLE
Fix 404 error when navigating to Progress page

### DIFF
--- a/desktop/src/components/Navigation.tsx
+++ b/desktop/src/components/Navigation.tsx
@@ -1,3 +1,4 @@
+import BarChartIcon from '@mui/icons-material/BarChart';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
 import HomeIcon from '@mui/icons-material/Home';
@@ -68,6 +69,7 @@ export const Navigation: FC = () => {
   const navItems = useMemo<NavItem[]>(() => [
     { path: '/', label: 'Home', icon: <HomeIcon /> },
     { path: '/curriculum', label: 'Lessons', icon: <SchoolIcon /> },
+    { path: '/progress-dashboard', label: 'Progress', icon: <BarChartIcon /> },
     { path: '/achievements', label: 'Achievements', icon: <EmojiEventsIcon /> },
     { path: '/profile', label: 'Profile', icon: <PersonIcon /> },
     { path: '/store', label: 'Store', icon: <ShoppingCartIcon /> },

--- a/desktop/src/routes.tsx
+++ b/desktop/src/routes.tsx
@@ -35,6 +35,7 @@ const SentryTest = lazy(() => import('@components/SentryTest'));
 const SentryReduxTest = lazy(() => import('@components/SentryReduxTest'));
 const SentryTransactionExample = lazy(() => import('@components/SentryTransactionExample'));
 const Achievements = lazy(() => import(/* webpackChunkName: "achievements" */ '@pages/AchievementsPage.tsx'));
+const ProgressDashboard = lazy(() => import(/* webpackChunkName: "progress" */ '@pages/ProgressDashboardPage.tsx'));
 
 /**
  * Desktop app routes
@@ -56,6 +57,7 @@ const AppRoutes = () => {
         <Route path="/subscription" element={<Subscription />} />
         <Route path="/store" element={<Store />} />
         <Route path="/review" element={<Review />} />
+        <Route path="/progress-dashboard" element={<ProgressDashboard />} />
         <Route path="/index.html" element={<Navigate to="/" replace />} />
         <Route path="/gamification" element={<GamificationPage />} />
         <Route path="/sentry-test" element={<SentryTest />} />


### PR DESCRIPTION
Description
This PR resolves an issue where users received a 404 error when trying to navigate to the Progress page from the side navigation menu.
Changes made:
Added the ProgressDashboard import to the routes.tsx file
Added a route for /progress-dashboard in the AppRoutes component
Added the Progress item to the navigation menu in the Navigation component with a BarChart icon
Technical details
Added const ProgressDashboard = lazy(() => import(/* webpackChunkName: "progress" */ '@pages/ProgressDashboardPage.tsx')); to routes.tsx
Added <Route path="/progress-dashboard" element={<ProgressDashboard />} /> to the routes configuration
Added the Progress item to the navigation sidebar with a BarChart icon
Fixed import ordering in Navigation.tsx to adhere to the project's linting rules
Testing
Navigation to the Progress page from the sidebar now works correctly
"View Progress" button on the homepage navigates correctly to the Progress dashboard
Notes
The issue occurred because the route was defined in the HomePage link but was missing from the routes configuration.